### PR TITLE
chore(dependencies): update `fast-paginate` library and PHP version

### DIFF
--- a/.github/workflows/run-tests.yml
+++ b/.github/workflows/run-tests.yml
@@ -13,11 +13,11 @@ jobs:
       fail-fast: true
       matrix:
         os: [ubuntu-latest]
-        php: [8.1]
-        laravel: [10.*]
+        php: [8.2]
+        laravel: [11.*]
         stability: [prefer-stable]
         include:
-          - laravel: 10.*
+          - laravel: 11.*
             testbench: ^8
 
     name: P${{ matrix.php }} - L${{ matrix.laravel }} - ${{ matrix.stability }} - ${{ matrix.os }}

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "php": "^8.2",
         "aaronfrancis/fast-paginate": "^2.0",
         "illuminate/contracts": "^10.0",
-        "inertiajs/inertia-laravel": "^0.6.3",
+        "inertiajs/inertia-laravel": "^2.0",
         "kirschbaum-development/eloquent-power-joins": "^3.3",
         "spatie/laravel-package-tools": "^1.14"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,16 +16,16 @@
         }
     ],
     "require": {
-        "php": "^8.1",
-        "hammerstone/fast-paginate": "^0.1.12",
+        "php": "^8.2",
+        "aaronfrancis/fast-paginate": "^2.0",
         "illuminate/contracts": "^10.0",
         "inertiajs/inertia-laravel": "^0.6.3",
         "kirschbaum-development/eloquent-power-joins": "^3.3",
         "spatie/laravel-package-tools": "^1.14"
     },
     "require-dev": {
+        "larastan/larastan": "^2.9",
         "nunomaduro/collision": "^7.0",
-        "nunomaduro/larastan": "^2.0",
         "orchestra/testbench": "^8.0",
         "pestphp/pest": "^2",
         "pestphp/pest-plugin-laravel": "^2",

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,42 +1,26 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<phpunit
-    xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-    xsi:noNamespaceSchemaLocation="vendor/phpunit/phpunit/phpunit.xsd"
-    backupGlobals="false"
-    backupStaticAttributes="false"
-    bootstrap="vendor/autoload.php"
-    colors="true"
-    convertErrorsToExceptions="true"
-    convertNoticesToExceptions="true"
-    convertWarningsToExceptions="true"
-    processIsolation="false"
-    stopOnFailure="false"
-    executionOrder="random"
-    failOnWarning="true"
-    failOnRisky="true"
-    failOnEmptyTestSuite="true"
-    beStrictAboutOutputDuringTests="true"
-    verbose="true"
->
-    <testsuites>
-        <testsuite name="Humweb Test Suite">
-            <directory>tests</directory>
-        </testsuite>
-    </testsuites>
-    <coverage>
-        <include>
-            <directory suffix=".php">./src</directory>
-        </include>
-        <exclude>
-        <file>src/InertiaTableServiceProvider.php</file>
-        </exclude>
-        <report>
-            <html outputDirectory="build/coverage"/>
-            <text outputFile="build/coverage.txt"/>
-            <clover outputFile="build/logs/clover.xml"/>
-        </report>
-    </coverage>
-    <logging>
-        <junit outputFile="build/report.junit.xml"/>
-    </logging>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="https://schema.phpunit.de/10.5/phpunit.xsd" backupGlobals="false" bootstrap="vendor/autoload.php" colors="true" processIsolation="false" stopOnFailure="false" executionOrder="random" failOnWarning="true" failOnRisky="true" failOnEmptyTestSuite="true" beStrictAboutOutputDuringTests="true" cacheDirectory=".phpunit.cache" backupStaticProperties="false">
+  <testsuites>
+    <testsuite name="Humweb Test Suite">
+      <directory>tests</directory>
+    </testsuite>
+  </testsuites>
+  <coverage>
+    <report>
+      <html outputDirectory="build/coverage"/>
+      <text outputFile="build/coverage.txt"/>
+      <clover outputFile="build/logs/clover.xml"/>
+    </report>
+  </coverage>
+  <logging>
+    <junit outputFile="build/report.junit.xml"/>
+  </logging>
+  <source>
+    <include>
+      <directory suffix=".php">./src</directory>
+    </include>
+    <exclude>
+      <file>src/InertiaTableServiceProvider.php</file>
+    </exclude>
+  </source>
 </phpunit>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -2,7 +2,7 @@
 
 namespace Humweb\Table\Tests;
 
-use Hammerstone\FastPaginate\FastPaginateProvider;
+use AaronFrancis\FastPaginate\FastPaginateProvider;
 use Humweb\Table\InertiaTableServiceProvider;
 use Illuminate\Database\Eloquent\Builder;
 use Illuminate\Database\Eloquent\Factories\Factory;


### PR DESCRIPTION
- Replaced `hammerstone/fast-paginate` with `aaronfrancis/fast-paginate` (v2.0).
- Updated minimum PHP version to 8.2 in `composer.json`.
- Replaced `nunomaduro/larastan` with `larastan/larastan` as a dev dependency.